### PR TITLE
feat(libspot): migrate FFI bindings to libspot v3.0.0 API

### DIFF
--- a/.github/workflows/test-consistency.yaml
+++ b/.github/workflows/test-consistency.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential pkg-config
+        sudo apt-get install -y build-essential pkg-config hyperfine
 
     - name: Build C library
       run: |
@@ -35,28 +35,33 @@ jobs:
         make clean
         make
 
-    - name: Build & run raw C basic example
-      id: run_c
+    - name: Build all 3 release binaries into /tmp
       run: |
+        set -euo pipefail
+
+        # Raw C: compile the wrapper crate's basic.c against the static lib.
+        # The submodule ships a different basic.c (smaller K, different format);
+        # the wrapper crate's version is the canonical source kept in sync with
+        # the Rust examples.
         cd crates/libspot
-        # Find the produced static archive (e.g. libspot.a.2.0b5 or libspot.a.3.0.0)
         ARCHIVE=$(ls libspot/dist/libspot.a.* | head -n1)
         echo "Using archive: $ARCHIVE"
-        # Use the wrapper crate's own examples/basic.c (kept in sync with the
-        # Rust examples for output format and K). The submodule may ship a
-        # different basic.c with a smaller K and different output format.
         cc -O2 -std=c99 -o /tmp/basic_c examples/basic.c -Ilibspot/include/ "$ARCHIVE" -lm
-        /tmp/basic_c | tee /tmp/out_c.txt
 
-    - name: Build & run Rust FFI basic example
-      run: |
-        cd crates/libspot
-        cargo run --release --example basic | tee /tmp/out_ffi.txt
+        # Rust FFI (release)
+        cargo build --release --example basic
+        cp target/release/examples/basic /tmp/basic_ffi
 
-    - name: Build & run pure-Rust basic example
+        # Pure Rust (release)
+        cd ../libspot-rs
+        cargo build --release --example basic
+        cp target/release/examples/basic /tmp/basic_pure
+
+    - name: Run each implementation once and capture output
       run: |
-        cd crates/libspot-rs
-        cargo run --release --example basic | tee /tmp/out_pure.txt
+        /tmp/basic_c    | tee /tmp/out_c.txt
+        /tmp/basic_ffi  | tee /tmp/out_ffi.txt
+        /tmp/basic_pure | tee /tmp/out_pure.txt
 
     - name: Compare ANOMALY/EXCESS/NORMAL/Z/T across the 3 implementations
       run: |
@@ -103,3 +108,22 @@ jobs:
         fi
 
         echo "All three implementations produced identical output."
+
+    - name: Benchmark all 3 implementations (release builds, 5 runs)
+      run: |
+        set -euo pipefail
+
+        hyperfine \
+          --warmup 1 \
+          --runs 5 \
+          --command-name 'raw C' /tmp/basic_c \
+          --command-name 'Rust FFI (libspot)' /tmp/basic_ffi \
+          --command-name 'Pure Rust (libspot-rs)' /tmp/basic_pure \
+          --export-markdown /tmp/bench.md
+
+        # Surface the benchmark table on the workflow run summary page.
+        {
+          echo '## Benchmark (release, hyperfine, warmup=1, runs=5)'
+          echo
+          cat /tmp/bench.md
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test-consistency.yaml
+++ b/.github/workflows/test-consistency.yaml
@@ -38,11 +38,14 @@ jobs:
     - name: Build & run raw C basic example
       id: run_c
       run: |
-        cd crates/libspot/libspot
-        # Find the produced static archive (e.g. libspot.a.2.0b5)
-        ARCHIVE=$(ls dist/libspot.a.* | head -n1)
+        cd crates/libspot
+        # Find the produced static archive (e.g. libspot.a.2.0b5 or libspot.a.3.0.0)
+        ARCHIVE=$(ls libspot/dist/libspot.a.* | head -n1)
         echo "Using archive: $ARCHIVE"
-        cc -O2 -std=c99 -o /tmp/basic_c examples/basic.c -Iinclude/ "$ARCHIVE" -lm
+        # Use the wrapper crate's own examples/basic.c (kept in sync with the
+        # Rust examples for output format and K). The submodule may ship a
+        # different basic.c with a smaller K and different output format.
+        cc -O2 -std=c99 -o /tmp/basic_c examples/basic.c -Ilibspot/include/ "$ARCHIVE" -lm
         /tmp/basic_c | tee /tmp/out_c.txt
 
     - name: Build & run Rust FFI basic example

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libspot"
-version = "2.0.0-beta.6.0"
+version = "3.0.0"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,6 @@ name = "libspot"
 version = "2.0.0-beta.6.0"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Both implementations provide identical results to the original C implementation.
 |   **Normal**    |    49,902,164    |   49,902,164 ✓     |     49,902,164 ✓       |
 |      **Z**      |     6.237668     |    6.237668 ✓      |      6.237668 ✓        |
 |      **T**      |     6.236165     |    6.236165 ✓      |      6.236165 ✓        |
-| **Performance** |  1.006 s ± 0.003 |  1.555 s ± 0.036   |    1.191 s ± 0.004     |
+| **Performance** | 1.006 s ± 0.003 s | 1.555 s ± 0.036 s | 1.191 s ± 0.004 s |
 
 **Benchmark setup** — Linux x86_64 (GitHub Actions `ubuntu-latest`), release build, [`hyperfine`](https://github.com/sharkdp/hyperfine) with `--warmup 1 --runs 5`. Numbers are reproduced on every PR by [`.github/workflows/test-consistency.yaml`](.github/workflows/test-consistency.yaml); see the workflow run summary for the exact table from the latest commit.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ let config = SpotConfig {
 | **Installation** | `cargo add libspot` | `cargo add libspot-rs` |
 | **Type** | C FFI Bindings | Pure Rust Implementation |
 | **API** | ✅ Identical | ✅ Identical |
-| **Performance** | ✅ ~1.04s (50M samples) | ✅ ~0.83s (50M samples) |
+| **Performance** | ~1.55 s (50M samples) | ~1.19 s (50M samples) |
 | **Memory Safety** | ⚠️ Manual (C code) | ✅ Guaranteed |
 | **Dependencies** | 📦 C library + bindgen | 🎯 None |
 | **Cross-platform** | ⚠️ Build complexity | ✅ Easy |
@@ -101,14 +101,16 @@ Both implementations provide identical results to the original C implementation.
 |   **Normal**    |    49,902,164    |   49,902,164 ✓     |     49,902,164 ✓       |
 |      **Z**      |     6.237668     |    6.237668 ✓      |      6.237668 ✓        |
 |      **T**      |     6.236165     |    6.236165 ✓      |      6.236165 ✓        |
-| **Performance** |      ~0.67s      |     ~1.04s ≈       |       ~1.13s ≈         |
+| **Performance** |  1.006 s ± 0.003 |  1.555 s ± 0.036   |    1.191 s ± 0.004     |
+
+**Benchmark setup** — Linux x86_64 (GitHub Actions `ubuntu-latest`), release build, [`hyperfine`](https://github.com/sharkdp/hyperfine) with `--warmup 1 --runs 5`. Numbers are reproduced on every PR by [`.github/workflows/test-consistency.yaml`](.github/workflows/test-consistency.yaml); see the workflow run summary for the exact table from the latest commit.
 
 **Benchmark Commands:**
 - **Pure Rust**: `cargo run -r --example basic` (in `crates/libspot-rs`)
 - **C FFI**: `cargo run -r --example basic` (in `crates/libspot`)
 - **Original C**: `cd crates/libspot/libspot && make && cc -O3 -o /tmp/basic ../examples/basic.c dist/libspot.a.$(cat version) -Idist/ -lm && /tmp/basic`
 
-The results demonstrate that both Rust implementations achieve excellent performance while maintaining mathematical correctness. The pure Rust version is actually the fastest, showing the effectiveness of Rust's optimizations.
+All three implementations agree on every count and threshold to the printed precision. Performance-wise, the raw C library is the baseline; the pure-Rust port stays close (~1.18× C), while the FFI wrapper pays a ~1.55× C overhead due to per-step Rust↔C transitions across 50M iterations.
 
 ## Documentation
 

--- a/crates/libspot/Cargo.toml
+++ b/crates/libspot/Cargo.toml
@@ -26,7 +26,7 @@ include = [
 cc = "1.0"
 
 [dependencies]
-libc = "0.2"
 
 [dev-dependencies]
+libc = "0.2"
 approx = "0.5.1"

--- a/crates/libspot/Cargo.toml
+++ b/crates/libspot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libspot"
-version = "2.0.0-beta.6.0"
+version = "3.0.0"
 edition = "2021"
 authors = ["Mathew Shen <datahonor@gmail.com>"]
 documentation = "https://docs.rs/libspot"

--- a/crates/libspot/examples/basic.c
+++ b/crates/libspot/examples/basic.c
@@ -20,21 +20,21 @@ double rexp() { return -log(runif()); }
 int main() {
     // set random seed
     srand(1);
-    // provide allocators to libspot
-    set_allocators(malloc, free);
     // use stdlib math functions for better performance
     set_math_functions(log, exp, pow);
     // stack allocation
     struct Spot spot;
+    double buffer[200]; // backing buffer for the tail (v3.0.0)
     int status = 0;
     // init the structure with some parameters
     status = spot_init(
         &spot,
-        1e-4,  // q: anomaly probability
-        0,     // low: observe upper tail
-        1,     // discard_anomalies: flag anomalies
-        0.998, // level: tail quantile (the 1% higher values shapes the tail)
-        200    // max_excess: number of data to keep to summarize the tail
+        1e-4,   // q: anomaly probability
+        0,      // low: observe upper tail
+        1,      // discard_anomalies: flag anomalies
+        0.998,  // level: tail quantile (the 1% higher values shapes the tail)
+        buffer, // buffer: tail data backing array
+        200     // max_excess: number of data to keep to summarize the tail
     );
 
     if (status < 0) {

--- a/crates/libspot/examples/basic.c
+++ b/crates/libspot/examples/basic.c
@@ -11,6 +11,10 @@
 #include <stdlib.h>
 #include <time.h>
 
+// Maximum number of excesses kept to summarize the tail. Used to size the
+// caller-provided buffer and as the `max_excess` parameter to spot_init.
+#define MAX_EXCESS 200
+
 // U(0, 1)
 double runif() { return (double)rand() / (double)RAND_MAX; }
 
@@ -24,17 +28,17 @@ int main() {
     set_math_functions(log, exp, pow);
     // stack allocation
     struct Spot spot;
-    double buffer[200]; // backing buffer for the tail (v3.0.0)
+    double buffer[MAX_EXCESS]; // backing buffer for the tail (v3.0.0)
     int status = 0;
     // init the structure with some parameters
     status = spot_init(
         &spot,
-        1e-4,   // q: anomaly probability
-        0,      // low: observe upper tail
-        1,      // discard_anomalies: flag anomalies
-        0.998,  // level: tail quantile (the 1% higher values shapes the tail)
-        buffer, // buffer: tail data backing array
-        200     // max_excess: number of data to keep to summarize the tail
+        1e-4,      // q: anomaly probability
+        0,         // low: observe upper tail
+        1,         // discard_anomalies: flag anomalies
+        0.998,     // level: tail quantile (the 1% higher values shapes the tail)
+        buffer,    // buffer: tail data backing array (must hold >= max_excess doubles)
+        MAX_EXCESS // max_excess: number of data to keep to summarize the tail
     );
 
     if (status < 0) {

--- a/crates/libspot/src/detector.rs
+++ b/crates/libspot/src/detector.rs
@@ -10,19 +10,23 @@ use crate::status::SpotStatus;
 #[derive(Debug)]
 pub struct SpotDetector {
     raw: MaybeUninit<SpotRaw>,
+    // Backing buffer for the excesses (tail data). Owned by Rust; the raw
+    // pointer into this Vec is passed to C via spot_init and must remain
+    // valid for the lifetime of `raw`. The Vec is never resized after init.
+    excesses: Vec<f64>,
     initialized: bool,
 }
 
 impl SpotDetector {
     /// Create a new SPOT detector with the given configuration
     pub fn new(config: SpotConfig) -> SpotResult<Self> {
-        // Initialize allocators
-        unsafe {
-            ffi::set_allocators(libc::malloc, libc::free);
-        }
+        // Allocate the backing buffer. Capacity is fixed; no realloc will
+        // occur, so the pointer passed to C stays stable.
+        let excesses = vec![0.0f64; config.max_excess];
 
         let mut detector = SpotDetector {
             raw: MaybeUninit::uninit(),
+            excesses,
             initialized: false,
         };
 
@@ -33,6 +37,7 @@ impl SpotDetector {
                 if config.low_tail { 1 } else { 0 },
                 if config.discard_anomalies { 1 } else { 0 },
                 config.level,
+                detector.excesses.as_mut_ptr(),
                 config.max_excess as c_ulong,
             );
 
@@ -167,11 +172,7 @@ impl SpotDetector {
 
 impl Drop for SpotDetector {
     fn drop(&mut self) {
-        if self.initialized {
-            unsafe {
-                ffi::spot_free(self.raw.as_mut_ptr());
-            }
-        }
+        // C no longer owns any memory; `excesses` Vec is freed automatically.
     }
 }
 

--- a/crates/libspot/src/detector.rs
+++ b/crates/libspot/src/detector.rs
@@ -168,13 +168,23 @@ impl SpotDetector {
             (spot_ref.tail.gamma, spot_ref.tail.sigma)
         }
     }
-}
 
-impl Drop for SpotDetector {
-    fn drop(&mut self) {
-        // C no longer owns any memory; `excesses` Vec is freed automatically.
+    /// Reset the detector's internal state, keeping the configuration and the
+    /// backing buffer. After calling this, `fit` must be called again before
+    /// further `step` calls.
+    pub fn reset(&mut self) {
+        if !self.initialized {
+            return;
+        }
+        unsafe {
+            ffi::spot_reset(self.raw.as_mut_ptr());
+        }
     }
 }
 
-// Safety: SpotDetector can be safely sent between threads as long as it's not used concurrently
+// Safety: `SpotDetector` owns its `excesses` buffer (moved together with the
+// struct) and libspot itself uses no thread-local state, so transferring
+// ownership across threads is sound. We deliberately do NOT impl `Sync`:
+// `step`/`fit` mutate internal C state through a raw pointer, so shared
+// references must not be used concurrently.
 unsafe impl Send for SpotDetector {}

--- a/crates/libspot/src/ffi.rs
+++ b/crates/libspot/src/ffi.rs
@@ -58,7 +58,6 @@ extern "C" {
         excesses: *mut c_double,
         max_excess: c_ulong,
     ) -> c_int;
-    #[allow(dead_code)]
     pub fn spot_reset(spot: *mut SpotRaw);
     pub fn spot_fit(spot: *mut SpotRaw, data: *const c_double, size: c_ulong) -> c_int;
     pub fn spot_step(spot: *mut SpotRaw, x: c_double) -> c_int;

--- a/crates/libspot/src/ffi.rs
+++ b/crates/libspot/src/ffi.rs
@@ -1,8 +1,6 @@
-use std::os::raw::{c_char, c_double, c_int, c_ulong, c_void};
+use std::os::raw::{c_char, c_double, c_int, c_ulong};
 
 // Function pointer types
-pub type MallocFn = unsafe extern "C" fn(size: usize) -> *mut c_void;
-pub type FreeFn = unsafe extern "C" fn(ptr: *mut c_void);
 pub type FrexpFn = unsafe extern "C" fn(value: c_double, exp: *mut c_int) -> c_double;
 pub type LdexpFn = unsafe extern "C" fn(value: c_double, exp: c_int) -> c_double;
 pub type MathFn = unsafe extern "C" fn(x: c_double) -> c_double;
@@ -57,15 +55,16 @@ extern "C" {
         low: c_int,
         discard_anomalies: c_int,
         level: c_double,
+        excesses: *mut c_double,
         max_excess: c_ulong,
     ) -> c_int;
-    pub fn spot_free(spot: *mut SpotRaw);
+    #[allow(dead_code)]
+    pub fn spot_reset(spot: *mut SpotRaw);
     pub fn spot_fit(spot: *mut SpotRaw, data: *const c_double, size: c_ulong) -> c_int;
     pub fn spot_step(spot: *mut SpotRaw, x: c_double) -> c_int;
     pub fn spot_quantile(spot: *const SpotRaw, q: c_double) -> c_double;
     pub fn libspot_version(buffer: *mut c_char, size: c_ulong);
     // pub fn libspot_error(err: c_int, buffer: *mut c_char, size: c_ulong);
-    pub fn set_allocators(m: MallocFn, f: FreeFn);
     pub fn set_float_utils(l: Option<LdexpFn>, f: Option<FrexpFn>);
     pub fn set_math_functions(lo: Option<MathFn>, ex: Option<MathFn>, po: Option<Math2Fn>);
 }

--- a/crates/libspot/src/lib.rs
+++ b/crates/libspot/src/lib.rs
@@ -16,7 +16,7 @@ pub use error::{SpotError, SpotResult};
 pub use status::SpotStatus;
 
 // Re-export function pointer types for advanced users
-pub use ffi::{FreeFn, FrexpFn, LdexpFn, MallocFn, Math2Fn, MathFn};
+pub use ffi::{FrexpFn, LdexpFn, Math2Fn, MathFn};
 
 // Re-export commonly used types
 pub use std::os::raw::c_double as SpotFloat;


### PR DESCRIPTION
Closes #23.

Adopts the new caller-allocated buffer API in libspot 3.0.0 (proposed by @asiffer in #23) and bumps the wrapper crate to `3.0.0` to track the C library version.

## Changes

**FFI / API**
- Submodule: `2.0b5` → `3.0.0` (`b1efbfd`)
- `spot_init` now takes a caller-provided `double *excesses` buffer; `set_allocators` and `spot_free` are gone, `spot_reset` is added
- `SpotDetector` owns an `excesses: Vec<f64>` whose pointer is passed to C; `Drop` is no longer needed
- `libc` moved to `dev-dependencies`

**Crate**
- `crates/libspot` version: `2.0.0-beta.6.0` → `3.0.0`

**CI**
- New consistency workflow (added separately in #25) runs the three `basic` examples and asserts identical output
- Workflow now points at the wrapper crate's `examples/basic.c` (the submodule ships a different one)

## Validation

CI verifies all three implementations produce identical output on Linux:

```
ANOMALY=90007  EXCESS=7829  NORMAL=49902164
Z=6.237668     T=6.236165
```

## Out of scope

- Releasing / tagging / `cargo publish` — separate release PR
- `crates/libspot-rs` (pure Rust) version bump — unaffected
