### PR TITLE
ci: post hyperfine benchmark as sticky PR comment

### DIFF
--- a/.github/workflows/test-consistency.yaml
+++ b/.github/workflows/test-consistency.yaml
@@ -10,6 +10,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   consistency:
     name: Verify all 3 implementations produce identical basic-example output
@@ -127,3 +131,44 @@ jobs:
           echo
           cat /tmp/bench.md
         } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Post benchmark results as PR comment
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const marker = '<!-- hyperfine-bench-comment -->';
+          const body = [
+            marker,
+            '## 📊 Benchmark results',
+            '',
+            `_release builds, \`hyperfine --warmup 1 --runs 5\` on \`${process.env.RUNNER_OS}\` (commit ${context.sha.substring(0, 7)})_`,
+            '',
+            fs.readFileSync('/tmp/bench.md', 'utf8'),
+            '',
+            `<sub>updated by [\`${context.workflow}\`](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})</sub>`,
+          ].join('\n');
+
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            per_page: 100,
+          });
+          const existing = comments.find(c => c.body && c.body.startsWith(marker));
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+          }

--- a/.github/workflows/test-consistency.yaml
+++ b/.github/workflows/test-consistency.yaml
@@ -113,6 +113,32 @@ jobs:
 
         echo "All three implementations produced identical output."
 
+        # Build a markdown table for the workflow summary / PR comment.
+        c_counts=$(grep -E '^ANOMALY=' /tmp/out_c.txt    | tail -n1)
+        c_zt=$(grep    -E '^Z='       /tmp/out_c.txt    | tail -n1)
+        f_counts=$(grep -E '^ANOMALY=' /tmp/out_ffi.txt  | tail -n1)
+        f_zt=$(grep    -E '^Z='       /tmp/out_ffi.txt  | tail -n1)
+        p_counts=$(grep -E '^ANOMALY=' /tmp/out_pure.txt | tail -n1)
+        p_zt=$(grep    -E '^Z='       /tmp/out_pure.txt | tail -n1)
+
+        # ANOMALY=N EXCESS=N NORMAL=N  -> three values
+        read -r c_a c_e c_n <<<"$(echo "$c_counts" | sed -E 's/[A-Z]+=//g')"
+        read -r f_a f_e f_n <<<"$(echo "$f_counts" | sed -E 's/[A-Z]+=//g')"
+        read -r p_a p_e p_n <<<"$(echo "$p_counts" | sed -E 's/[A-Z]+=//g')"
+        read -r c_z c_t     <<<"$(echo "$c_zt"     | sed -E 's/[A-Z]+=//g')"
+        read -r f_z f_t     <<<"$(echo "$f_zt"     | sed -E 's/[A-Z]+=//g')"
+        read -r p_z p_t     <<<"$(echo "$p_zt"     | sed -E 's/[A-Z]+=//g')"
+
+        {
+          echo '| Metric | C | Rust FFI | Pure Rust |'
+          echo '|---|---:|---:|---:|'
+          printf '| Anomalies | %s | %s | %s |\n' "$c_a" "$f_a" "$p_a"
+          printf '| Excess    | %s | %s | %s |\n' "$c_e" "$f_e" "$p_e"
+          printf '| Normal    | %s | %s | %s |\n' "$c_n" "$f_n" "$p_n"
+          printf '| Z         | %s | %s | %s |\n' "$c_z" "$f_z" "$p_z"
+          printf '| T         | %s | %s | %s |\n' "$c_t" "$f_t" "$p_t"
+        } > /tmp/consistency.md
+
     - name: Benchmark all 3 implementations (release builds, 5 runs)
       run: |
         set -euo pipefail
@@ -127,27 +153,39 @@ jobs:
 
         # Surface the benchmark table on the workflow run summary page.
         {
+          echo '## Consistency (basic example, single run)'
+          echo
+          cat /tmp/consistency.md
+          echo
           echo '## Benchmark (release, hyperfine, warmup=1, runs=5)'
           echo
           cat /tmp/bench.md
         } >> "$GITHUB_STEP_SUMMARY"
 
-    - name: Post benchmark results as PR comment
+    - name: Post results as PR comment
       if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
       uses: actions/github-script@v7
       with:
         script: |
           const fs = require('fs');
           const marker = '<!-- hyperfine-bench-comment -->';
+          const sha = context.sha.substring(0, 7);
+          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
           const body = [
             marker,
-            '## 📊 Benchmark results',
+            '### ▸ Cross-implementation results',
             '',
-            `_release builds, \`hyperfine --warmup 1 --runs 5\` on \`${process.env.RUNNER_OS}\` (commit ${context.sha.substring(0, 7)})_`,
+            `_commit \`${sha}\` · \`${process.env.RUNNER_OS}\` · release builds_`,
             '',
-            fs.readFileSync('/tmp/bench.md', 'utf8'),
+            '#### Consistency (basic example)',
             '',
-            `<sub>updated by [\`${context.workflow}\`](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})</sub>`,
+            fs.readFileSync('/tmp/consistency.md', 'utf8').trim(),
+            '',
+            '#### Benchmark (`hyperfine --warmup 1 --runs 5`)',
+            '',
+            fs.readFileSync('/tmp/bench.md', 'utf8').trim(),
+            '',
+            `<sub>updated by [${context.workflow}](${runUrl})</sub>`,
           ].join('\n');
 
           const { data: comments } = await github.rest.issues.listComments({


### PR DESCRIPTION
Adds a step to `.github/workflows/test-consistency.yaml` that posts the hyperfine markdown table as a **sticky comment** on the PR (one comment per PR, updated in place on each run).

## How it works

- Uses [`actions/github-script@v7`](https://github.com/actions/github-script) (no extra deps).
- Identifies its own comment via an HTML marker (`<!-- hyperfine-bench-comment -->`); on subsequent runs it edits that comment instead of creating a new one.
- Adds workflow-level `permissions: pull-requests: write` so the default `GITHUB_TOKEN` can comment.
- Guarded by `if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository` so it skips push events and forked-PR runs (where the token is read-only).

## Verification

This PR itself should produce a comment with the benchmark table once CI finishes — if it doesn't, the step needs adjusting.
