### PR TITLE
feat(libspot-rs): add SpotDetector::reset() for API parity

### DIFF
--- a/crates/libspot-rs/src/peaks.rs
+++ b/crates/libspot-rs/src/peaks.rs
@@ -47,6 +47,15 @@ impl Peaks {
         self.container.size()
     }
 
+    /// Reset the peaks to their empty state, keeping the allocated buffer.
+    pub(crate) fn reset(&mut self) {
+        self.e = 0.0;
+        self.e2 = 0.0;
+        self.min = f64::NAN;
+        self.max = f64::NAN;
+        self.container.reset();
+    }
+
     /// Add a new data point into the peaks
     pub fn push(&mut self, x: f64) {
         let erased = self.container.push(x);

--- a/crates/libspot-rs/src/peaks.rs
+++ b/crates/libspot-rs/src/peaks.rs
@@ -169,6 +169,34 @@ mod tests {
     use approx::assert_relative_eq;
 
     #[test]
+    fn test_peaks_reset_clears_stats() {
+        let mut p = Peaks::new(4).unwrap();
+        for v in [1.0, 2.0, 3.0, 4.0, 5.0] {
+            p.push(v); // last push will wrap and erase 1.0
+        }
+        assert!(p.size() > 0);
+        assert!(!p.sum().is_nan());
+
+        p.reset();
+
+        assert_eq!(p.size(), 0);
+        assert_relative_eq!(p.sum(), 0.0);
+        assert_relative_eq!(p.sum_squares(), 0.0);
+        assert!(p.min().is_nan());
+        assert!(p.max().is_nan());
+        assert!(p.mean().is_nan());
+        assert!(p.variance().is_nan());
+
+        // After reset, accumulators rebuild correctly from scratch.
+        p.push(10.0);
+        p.push(20.0);
+        assert_eq!(p.size(), 2);
+        assert_relative_eq!(p.sum(), 30.0);
+        assert_relative_eq!(p.min(), 10.0);
+        assert_relative_eq!(p.max(), 20.0);
+    }
+
+    #[test]
     fn test_peaks_creation() {
         let peaks = Peaks::new(5).unwrap();
         assert_eq!(peaks.size(), 0);

--- a/crates/libspot-rs/src/spot.rs
+++ b/crates/libspot-rs/src/spot.rs
@@ -250,6 +250,19 @@ impl SpotDetector {
         (self.tail.gamma(), self.tail.sigma())
     }
 
+    /// Reset the detector's internal state, keeping the configuration and the
+    /// backing buffer. After calling this, [`fit`](Self::fit) must be called
+    /// again before further [`step`](Self::step) calls.
+    ///
+    /// This mirrors the `spot_reset` C API exposed by the FFI wrapper crate.
+    pub fn reset(&mut self) {
+        self.anomaly_threshold = f64::NAN;
+        self.excess_threshold = f64::NAN;
+        self.nt = 0;
+        self.n = 0;
+        self.tail.reset();
+    }
+
     /// Get the current size of the tail data
     pub fn tail_size(&self) -> usize {
         self.tail.size()
@@ -366,6 +379,39 @@ mod tests {
         let result = spot.step(f64::NAN);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), SpotError::DataIsNaN);
+    }
+
+    #[test]
+    fn test_spot_reset_returns_to_pristine_state() {
+        let config = SpotConfig::default();
+        let mut spot = SpotDetector::new(config.clone()).unwrap();
+
+        let data: Vec<f64> = (0..1000).map(|i| (i as f64 / 1000.0) * 2.0 - 1.0).collect();
+        spot.fit(&data).unwrap();
+        for v in &data {
+            let _ = spot.step(*v).unwrap();
+        }
+        assert!(spot.n() > 0);
+        assert!(!spot.anomaly_threshold().is_nan());
+
+        spot.reset();
+
+        // Looks like a freshly constructed detector.
+        assert!(spot.anomaly_threshold().is_nan());
+        assert!(spot.excess_threshold().is_nan());
+        assert_eq!(spot.n(), 0);
+        assert_eq!(spot.nt(), 0);
+        assert_eq!(spot.tail_size(), 0);
+        assert_eq!(spot.config(), Some(config.clone()));
+
+        // Re-fit produces identical numbers to a fresh detector.
+        let mut fresh = SpotDetector::new(config).unwrap();
+        spot.fit(&data).unwrap();
+        fresh.fit(&data).unwrap();
+        assert_relative_eq!(spot.anomaly_threshold(), fresh.anomaly_threshold());
+        assert_relative_eq!(spot.excess_threshold(), fresh.excess_threshold());
+        assert_eq!(spot.nt(), fresh.nt());
+        assert_eq!(spot.n(), fresh.n());
     }
 
     #[test]

--- a/crates/libspot-rs/src/spot.rs
+++ b/crates/libspot-rs/src/spot.rs
@@ -415,6 +415,77 @@ mod tests {
     }
 
     #[test]
+    fn test_spot_reset_before_fit_is_noop_safe() {
+        // Calling reset on a freshly constructed detector must not panic
+        // and must leave the detector in the same observable state.
+        let mut spot = SpotDetector::new(SpotConfig::default()).unwrap();
+        spot.reset();
+        assert!(spot.anomaly_threshold().is_nan());
+        assert!(spot.excess_threshold().is_nan());
+        assert_eq!(spot.n(), 0);
+        assert_eq!(spot.nt(), 0);
+        assert_eq!(spot.tail_size(), 0);
+
+        // Fit still works normally afterwards.
+        let data: Vec<f64> = (0..500).map(|i| (i as f64 / 500.0) * 2.0 - 1.0).collect();
+        spot.fit(&data).unwrap();
+        assert!(!spot.anomaly_threshold().is_nan());
+    }
+
+    #[test]
+    fn test_spot_reset_is_idempotent() {
+        let mut spot = SpotDetector::new(SpotConfig::default()).unwrap();
+        let data: Vec<f64> = (0..500).map(|i| (i as f64 / 500.0) * 2.0 - 1.0).collect();
+        spot.fit(&data).unwrap();
+        for v in &data {
+            let _ = spot.step(*v).unwrap();
+        }
+
+        spot.reset();
+        let after_first_n = spot.n();
+        let after_first_nt = spot.nt();
+        let after_first_size = spot.tail_size();
+
+        spot.reset();
+        assert_eq!(spot.n(), after_first_n);
+        assert_eq!(spot.nt(), after_first_nt);
+        assert_eq!(spot.tail_size(), after_first_size);
+        assert!(spot.anomaly_threshold().is_nan());
+        assert!(spot.excess_threshold().is_nan());
+    }
+
+    #[test]
+    fn test_spot_reset_then_fit_then_step_full_cycle() {
+        // Full lifecycle: fit -> step -> reset -> fit again -> step again must
+        // produce the same step classifications as a fresh detector running
+        // the same fit+step sequence.
+        let config = SpotConfig::default();
+        let train: Vec<f64> = (0..1000).map(|i| (i as f64 / 1000.0) * 2.0 - 1.0).collect();
+        let probe: Vec<f64> = (0..200).map(|i| (i as f64 / 100.0) - 1.0).collect();
+
+        let mut reused = SpotDetector::new(config.clone()).unwrap();
+        reused.fit(&train).unwrap();
+        for v in &probe {
+            let _ = reused.step(*v).unwrap();
+        }
+        reused.reset();
+        reused.fit(&train).unwrap();
+        let reused_classifications: Vec<SpotStatus> =
+            probe.iter().map(|&v| reused.step(v).unwrap()).collect();
+
+        let mut fresh = SpotDetector::new(config).unwrap();
+        fresh.fit(&train).unwrap();
+        let fresh_classifications: Vec<SpotStatus> =
+            probe.iter().map(|&v| fresh.step(v).unwrap()).collect();
+
+        assert_eq!(reused_classifications, fresh_classifications);
+        assert_relative_eq!(reused.anomaly_threshold(), fresh.anomaly_threshold());
+        assert_relative_eq!(reused.excess_threshold(), fresh.excess_threshold());
+        assert_eq!(reused.nt(), fresh.nt());
+        assert_eq!(reused.n(), fresh.n());
+    }
+
+    #[test]
     fn test_spot_low_tail() {
         let config = SpotConfig {
             low_tail: true,

--- a/crates/libspot-rs/src/tail.rs
+++ b/crates/libspot-rs/src/tail.rs
@@ -153,6 +153,24 @@ mod tests {
     use crate::error::SpotError;
 
     #[test]
+    fn test_tail_reset_clears_gpd_params_and_peaks() {
+        let mut tail = Tail::new(50).unwrap();
+        for i in 0..40 {
+            tail.push(0.1 + i as f64 * 0.05);
+        }
+        let _ = tail.fit();
+        assert!(tail.size() > 0);
+        // gamma/sigma may be NaN if the fit fails on this trivial input,
+        // so we only assert they're cleared post-reset, not pre-reset.
+
+        tail.reset();
+
+        assert_eq!(tail.size(), 0);
+        assert!(tail.gamma().is_nan());
+        assert!(tail.sigma().is_nan());
+    }
+
+    #[test]
     fn test_tail_creation() {
         let tail = Tail::new(10).unwrap();
         assert_eq!(tail.size(), 0);

--- a/crates/libspot-rs/src/tail.rs
+++ b/crates/libspot-rs/src/tail.rs
@@ -43,6 +43,13 @@ impl Tail {
         self.peaks.push(x);
     }
 
+    /// Reset the tail to its initial state, keeping the allocated buffer.
+    pub(crate) fn reset(&mut self) {
+        self.gamma = f64::NAN;
+        self.sigma = f64::NAN;
+        self.peaks.reset();
+    }
+
     /// Fit the GPD parameters using the available estimators
     /// Returns the log-likelihood of the best fit
     pub fn fit(&mut self) -> f64 {

--- a/crates/libspot-rs/src/ubend.rs
+++ b/crates/libspot-rs/src/ubend.rs
@@ -172,6 +172,43 @@ mod tests {
     use approx::assert_relative_eq;
 
     #[test]
+    fn test_ubend_reset_clears_state_and_preserves_capacity() {
+        let mut ub = Ubend::new(3).unwrap();
+        // Fill past capacity so `filled = true` and `last_erased_data` is set.
+        let _ = ub.push(1.0);
+        let _ = ub.push(2.0);
+        let _ = ub.push(3.0);
+        let erased = ub.push(4.0);
+        assert_relative_eq!(erased, 1.0);
+        assert_eq!(ub.size(), 3);
+
+        ub.reset();
+
+        // Empty again, but capacity (and the underlying Vec) is preserved.
+        assert_eq!(ub.size(), 0);
+        assert_eq!(ub.capacity, 3);
+        assert_eq!(ub.cursor, 0);
+        assert!(!ub.filled);
+        assert!(ub.last_erased_data.is_nan());
+        assert_eq!(ub.data.len(), 3); // Vec not reallocated
+
+        // After reset, the next push behaves like on a fresh Ubend:
+        // it returns NaN (nothing erased) instead of the old `last_erased_data`.
+        let erased_after_reset = ub.push(10.0);
+        assert!(erased_after_reset.is_nan());
+        assert_eq!(ub.size(), 1);
+    }
+
+    #[test]
+    fn test_ubend_reset_is_idempotent() {
+        let mut ub = Ubend::new(2).unwrap();
+        ub.reset();
+        ub.reset();
+        assert_eq!(ub.size(), 0);
+        assert!(ub.last_erased_data.is_nan());
+    }
+
+    #[test]
     fn test_ubend_creation() {
         let ubend = Ubend::new(5).unwrap();
         assert_eq!(ubend.capacity(), 5);

--- a/crates/libspot-rs/src/ubend.rs
+++ b/crates/libspot-rs/src/ubend.rs
@@ -54,6 +54,17 @@ impl Ubend {
         }
     }
 
+    /// Reset the container to its empty state, keeping the allocated buffer.
+    ///
+    /// After `reset`, [`size`](Self::size) returns 0 and the next [`push`](Self::push)
+    /// behaves as on a freshly constructed container. The underlying `Vec`
+    /// allocation is preserved (no realloc).
+    pub(crate) fn reset(&mut self) {
+        self.cursor = 0;
+        self.filled = false;
+        self.last_erased_data = f64::NAN;
+    }
+
     /// Push a new value into the container
     /// Returns the value that was erased (if any), otherwise NaN
     pub fn push(&mut self, x: f64) -> f64 {


### PR DESCRIPTION
## Summary

Adds `SpotDetector::reset()` to the pure-Rust `libspot-rs` crate so its public API matches the FFI wrapper crate after the libspot C v3 migration.

## Details

- Adds public `SpotDetector::reset()`.
- Adds internal `pub(crate)` reset helpers for `Tail`, `Peaks`, and `Ubend`.
- Preserves configuration and backing buffers across reset, matching the C `spot_reset` semantics.
- Keeps `SpotConfig.max_excess` unchanged because the pure-Rust crate already has matching semantics.

## Tests

- `cargo fmt --check`
- `cargo test reset`
- `cargo test`
- `prek run --all-files`

The new reset tests cover idempotency, fit-before-reset safety, full fit/step/reset/fit/step lifecycle equivalence, and low-level buffer/state cleanup.
