### PR TITLE
Add MOM estimator options

### DIFF
--- a/crates/libspot-rs/README.md
+++ b/crates/libspot-rs/README.md
@@ -36,6 +36,32 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Features
 
+### Estimator and threshold options
+
+`SpotDetector::new(config)` keeps the default behavior: it uses `SpotEstimator::Best`, the P2 initial threshold, and the historical `>=` excess update rule.
+
+To reproduce algorithms that explicitly use FluxEV-style MOM-SPOT, configure all options explicitly:
+
+```rust,ignore
+use libspot_rs::{
+    SpotConfig, SpotDetector, SpotEstimator, SpotExcessUpdate, SpotInitialThreshold,
+};
+
+let config = SpotConfig {
+    q: 0.001,
+    level: 0.98,
+    max_excess: 10_000,
+    ..SpotConfig::default()
+};
+
+let mut detector = SpotDetector::new_with_full_options(
+    config,
+    SpotEstimator::Mom,
+    SpotInitialThreshold::Empirical,
+    SpotExcessUpdate::Greater,
+)?;
+```
+
 ### Serialization (Model Persistence)
 
 Serialization support is **enabled by default**. SPOT detectors can be serialized and deserialized for model deployment:

--- a/crates/libspot-rs/src/config.rs
+++ b/crates/libspot-rs/src/config.rs
@@ -1,5 +1,45 @@
 //! Configuration types for SPOT detector
 
+/// GPD parameter estimator used by SPOT.
+///
+/// The default keeps the historical libspot-rs behavior: try the supported
+/// estimators and keep the fit with the best log-likelihood.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum SpotEstimator {
+    /// Try the available estimators and keep the best log-likelihood.
+    #[default]
+    Best,
+    /// Force Method of Moments estimation.
+    Mom,
+}
+
+/// Initial excess-threshold selection strategy.
+///
+/// The default keeps the historical libspot-rs behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum SpotInitialThreshold {
+    /// Use the P2 streaming quantile estimator.
+    #[default]
+    P2,
+    /// Use the empirical sorted quantile from the initial batch.
+    Empirical,
+}
+
+/// Streaming excess update condition.
+///
+/// The default keeps the historical libspot-rs behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum SpotExcessUpdate {
+    /// Update the tail when `value >= excess_threshold`.
+    #[default]
+    GreaterOrEqual,
+    /// Update the tail only when `value > excess_threshold`.
+    Greater,
+}
+
 /// Configuration parameters for SPOT detector
 ///
 /// # Serialization
@@ -71,5 +111,23 @@ mod tests {
         assert_eq!(config1.discard_anomalies, config2.discard_anomalies);
         assert_relative_eq!(config1.level, config2.level);
         assert_eq!(config1.max_excess, config2.max_excess);
+    }
+
+    #[test]
+    fn test_spot_estimator_default_keeps_existing_behavior() {
+        assert_eq!(SpotEstimator::default(), SpotEstimator::Best);
+    }
+
+    #[test]
+    fn test_spot_initial_threshold_default_keeps_existing_behavior() {
+        assert_eq!(SpotInitialThreshold::default(), SpotInitialThreshold::P2);
+    }
+
+    #[test]
+    fn test_spot_excess_update_default_keeps_existing_behavior() {
+        assert_eq!(
+            SpotExcessUpdate::default(),
+            SpotExcessUpdate::GreaterOrEqual
+        );
     }
 }

--- a/crates/libspot-rs/src/estimator.rs
+++ b/crates/libspot-rs/src/estimator.rs
@@ -30,6 +30,34 @@ pub fn mom_estimator(peaks: &Peaks) -> (f64, f64, f64) {
     (gamma, sigma, log_likelihood)
 }
 
+/// Method of Moments estimator using sample variance.
+///
+/// This matches the MOM estimator used by FluxEV's SPOT integration.
+pub fn mom_sample_variance_estimator(peaks: &Peaks) -> (f64, f64, f64) {
+    let nt_local = peaks.size();
+    if nt_local < 2 {
+        return (f64::NAN, f64::NAN, f64::NAN);
+    }
+
+    let e = peaks.mean();
+    let mut sum_sq_delta = 0.0;
+    for &value in peaks.container().raw_data().iter().take(nt_local) {
+        let delta = value - e;
+        sum_sq_delta += delta * delta;
+    }
+    let v = sum_sq_delta / (nt_local as f64 - 1.0);
+
+    if e.is_nan() || v.is_nan() || v <= 0.0 {
+        return (f64::NAN, f64::NAN, f64::NAN);
+    }
+
+    let r = e * e / v;
+    let gamma = 0.5 * (1.0 - r);
+    let sigma = 0.5 * e * (1.0 + r);
+
+    (gamma, sigma, 0.0)
+}
+
 /// Grimshaw estimator for GPD parameters
 pub fn grimshaw_estimator(peaks: &Peaks) -> (f64, f64, f64) {
     let mini = peaks.min();
@@ -297,6 +325,21 @@ mod tests {
         assert!(!sigma.is_nan());
         assert!(!llhood.is_nan());
         assert!(sigma > 0.0); // Sigma should be positive
+    }
+
+    #[test]
+    fn test_mom_sample_variance_estimator_normal_case() {
+        let mut peaks = Peaks::new(10).unwrap();
+        for value in [1.0, 2.0, 3.0, 4.0] {
+            peaks.push(value);
+        }
+
+        let (gamma, sigma, llhood) = mom_sample_variance_estimator(&peaks);
+
+        assert!(gamma.is_finite());
+        assert!(sigma.is_finite());
+        assert!(sigma > 0.0);
+        assert_relative_eq!(llhood, 0.0);
     }
 
     #[test]

--- a/crates/libspot-rs/src/lib.rs
+++ b/crates/libspot-rs/src/lib.rs
@@ -59,7 +59,7 @@ mod tail;
 mod ubend;
 
 // Re-export public types
-pub use config::SpotConfig;
+pub use config::{SpotConfig, SpotEstimator, SpotExcessUpdate, SpotInitialThreshold};
 pub use error::{SpotError, SpotResult};
 pub use peaks::Peaks;
 pub use spot::SpotDetector;

--- a/crates/libspot-rs/src/spot.rs
+++ b/crates/libspot-rs/src/spot.rs
@@ -33,7 +33,7 @@
 //! let status = loaded.step(50.0);
 //! ```
 
-use crate::config::SpotConfig;
+use crate::config::{SpotConfig, SpotEstimator, SpotExcessUpdate, SpotInitialThreshold};
 
 use crate::error::{SpotError, SpotResult};
 use crate::p2::p2_quantile;
@@ -92,6 +92,15 @@ pub struct SpotDetector {
     nt: usize,
     /// Total number of seen data
     n: usize,
+    /// GPD parameter estimator policy
+    #[cfg_attr(feature = "serde", serde(default))]
+    estimator: SpotEstimator,
+    /// Initial excess threshold selection strategy
+    #[cfg_attr(feature = "serde", serde(default))]
+    initial_threshold: SpotInitialThreshold,
+    /// Streaming excess update condition
+    #[cfg_attr(feature = "serde", serde(default))]
+    excess_update: SpotExcessUpdate,
     /// GPD Tail
     tail: Tail,
 }
@@ -99,6 +108,35 @@ pub struct SpotDetector {
 impl SpotDetector {
     /// Create a new SPOT detector with the given configuration
     pub fn new(config: SpotConfig) -> SpotResult<Self> {
+        Self::new_with_estimator(config, SpotEstimator::default())
+    }
+
+    /// Create a new SPOT detector with the given configuration and estimator.
+    pub fn new_with_estimator(config: SpotConfig, estimator: SpotEstimator) -> SpotResult<Self> {
+        Self::new_with_options(config, estimator, SpotInitialThreshold::default())
+    }
+
+    /// Create a new SPOT detector with explicit estimator and initial threshold options.
+    pub fn new_with_options(
+        config: SpotConfig,
+        estimator: SpotEstimator,
+        initial_threshold: SpotInitialThreshold,
+    ) -> SpotResult<Self> {
+        Self::new_with_full_options(
+            config,
+            estimator,
+            initial_threshold,
+            SpotExcessUpdate::default(),
+        )
+    }
+
+    /// Create a new SPOT detector with all algorithm options explicit.
+    pub fn new_with_full_options(
+        config: SpotConfig,
+        estimator: SpotEstimator,
+        initial_threshold: SpotInitialThreshold,
+        excess_update: SpotExcessUpdate,
+    ) -> SpotResult<Self> {
         // Validate parameters
         if config.level < 0.0 || config.level >= 1.0 {
             return Err(SpotError::LevelOutOfBounds);
@@ -119,6 +157,9 @@ impl SpotDetector {
             excess_threshold: f64::NAN,
             nt: 0,
             n: 0,
+            estimator,
+            initial_threshold,
+            excess_update,
             tail: Tail::new(config.max_excess)?,
         })
     }
@@ -132,9 +173,9 @@ impl SpotDetector {
         // Compute excess threshold using P2 quantile estimator
         let et = if self.low {
             // Take the low quantile (1 - level)
-            p2_quantile(1.0 - self.level, data)
+            self.initial_quantile(1.0 - self.level, data)
         } else {
-            p2_quantile(self.level, data)
+            self.initial_quantile(self.level, data)
         };
 
         if et.is_nan() {
@@ -155,7 +196,7 @@ impl SpotDetector {
         }
 
         // Fit the tail with the pushed data
-        self.tail.fit();
+        self.tail.fit_with(self.estimator);
 
         // Compute first anomaly threshold
         self.anomaly_threshold = self.quantile(self.q);
@@ -180,17 +221,26 @@ impl SpotDetector {
         self.n += 1;
 
         let ex = self.up_down * (value - self.excess_threshold);
-        if ex >= 0.0 {
+        if self.should_update_excess(ex) {
             // Increment number of excesses
             self.nt += 1;
             self.tail.push(ex);
-            self.tail.fit();
+            self.tail.fit_with(self.estimator);
             // Update threshold
             self.anomaly_threshold = self.quantile(self.q);
             return Ok(SpotStatus::Excess);
         }
 
         Ok(SpotStatus::Normal)
+    }
+
+    /// Record a normal observation without updating the tail.
+    ///
+    /// This is useful when the caller has already decided to suppress a
+    /// missing or invalid sample but still wants the stream length to advance.
+    /// The regular [`step`](Self::step) API remains strict about `NaN` inputs.
+    pub fn observe_normal(&mut self) {
+        self.n += 1;
     }
 
     /// Get the quantile for a given probability
@@ -250,6 +300,21 @@ impl SpotDetector {
         (self.tail.gamma(), self.tail.sigma())
     }
 
+    /// Get the configured estimator policy.
+    pub fn estimator(&self) -> SpotEstimator {
+        self.estimator
+    }
+
+    /// Get the configured initial threshold strategy.
+    pub fn initial_threshold(&self) -> SpotInitialThreshold {
+        self.initial_threshold
+    }
+
+    /// Get the configured streaming excess update condition.
+    pub fn excess_update(&self) -> SpotExcessUpdate {
+        self.excess_update
+    }
+
     /// Reset the detector's internal state, keeping the configuration and the
     /// backing buffer. After calling this, [`fit`](Self::fit) must be called
     /// again before further [`step`](Self::step) calls.
@@ -292,6 +357,31 @@ impl SpotDetector {
     pub fn peaks_data(&self) -> Vec<f64> {
         self.tail.peaks().container().data()
     }
+
+    fn initial_quantile(&self, level: f64, data: &[f64]) -> f64 {
+        match self.initial_threshold {
+            SpotInitialThreshold::P2 => p2_quantile(level, data),
+            SpotInitialThreshold::Empirical => empirical_quantile(level, data),
+        }
+    }
+
+    fn should_update_excess(&self, excess: f64) -> bool {
+        match self.excess_update {
+            SpotExcessUpdate::GreaterOrEqual => excess >= 0.0,
+            SpotExcessUpdate::Greater => excess > 0.0,
+        }
+    }
+}
+
+fn empirical_quantile(level: f64, data: &[f64]) -> f64 {
+    let mut sorted: Vec<f64> = data.iter().copied().filter(|value| value.is_finite()).collect();
+    if sorted.is_empty() {
+        return f64::NAN;
+    }
+
+    sorted.sort_by(|a, b| a.total_cmp(b));
+    let index = ((level - level.floor()) * sorted.len() as f64) as usize;
+    sorted[index.min(sorted.len() - 1)]
 }
 
 #[cfg(test)]
@@ -312,6 +402,51 @@ mod tests {
         assert!(spot.excess_threshold().is_nan());
         assert_eq!(spot.n(), 0);
         assert_eq!(spot.nt(), 0);
+        assert_eq!(spot.estimator(), SpotEstimator::Best);
+        assert_eq!(spot.initial_threshold(), SpotInitialThreshold::P2);
+        assert_eq!(spot.excess_update(), SpotExcessUpdate::GreaterOrEqual);
+    }
+
+    #[test]
+    fn test_spot_creation_with_mom_estimator() {
+        let config = SpotConfig {
+            q: 0.001,
+            level: 0.98,
+            max_excess: 10_000,
+            ..SpotConfig::default()
+        };
+        let mut spot = SpotDetector::new_with_full_options(
+            config,
+            SpotEstimator::Mom,
+            SpotInitialThreshold::Empirical,
+            SpotExcessUpdate::Greater,
+        )
+        .unwrap();
+
+        let data: Vec<f64> = (0..1000)
+            .map(|i| {
+                let x = i as f64 * 0.1;
+                x.sin() + (x * 0.37).cos() * 0.1 + 5.0
+            })
+            .collect();
+
+        spot.fit(&data).unwrap();
+
+        assert_eq!(spot.estimator(), SpotEstimator::Mom);
+        assert_eq!(spot.initial_threshold(), SpotInitialThreshold::Empirical);
+        assert_eq!(spot.excess_update(), SpotExcessUpdate::Greater);
+        assert!(!spot.anomaly_threshold().is_nan());
+        assert_eq!(spot.step(5.5).unwrap(), SpotStatus::Normal);
+        assert_eq!(spot.step(100.0).unwrap(), SpotStatus::Anomaly);
+    }
+
+    #[test]
+    fn test_empirical_quantile_matches_sorted_index() {
+        let data = [5.0, 1.0, 3.0, 2.0, 4.0];
+
+        assert_relative_eq!(empirical_quantile(0.0, &data), 1.0);
+        assert_relative_eq!(empirical_quantile(0.5, &data), 3.0);
+        assert_relative_eq!(empirical_quantile(0.98, &data), 5.0);
     }
 
     #[test]
@@ -379,6 +514,26 @@ mod tests {
         let result = spot.step(f64::NAN);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), SpotError::DataIsNaN);
+    }
+
+    #[test]
+    fn test_spot_observe_normal_advances_count_only() {
+        let config = SpotConfig::default();
+        let mut spot = SpotDetector::new(config).unwrap();
+
+        let data: Vec<f64> = (0..1000).map(|i| (i as f64 / 1000.0) * 2.0 - 1.0).collect();
+        spot.fit(&data).unwrap();
+        let n = spot.n();
+        let nt = spot.nt();
+        let anomaly_threshold = spot.anomaly_threshold();
+        let excess_threshold = spot.excess_threshold();
+
+        spot.observe_normal();
+
+        assert_eq!(spot.n(), n + 1);
+        assert_eq!(spot.nt(), nt);
+        assert_relative_eq!(spot.anomaly_threshold(), anomaly_threshold);
+        assert_relative_eq!(spot.excess_threshold(), excess_threshold);
     }
 
     #[test]

--- a/crates/libspot-rs/src/spot.rs
+++ b/crates/libspot-rs/src/spot.rs
@@ -166,11 +166,12 @@ impl SpotDetector {
 
     /// Fit the model using initial training data
     pub fn fit(&mut self, data: &[f64]) -> SpotResult<()> {
-        // Reset counters
+        // Reset learned state so repeated fits behave like fitting a fresh detector.
         self.nt = 0;
         self.n = data.len();
+        self.tail.reset();
 
-        // Compute excess threshold using P2 quantile estimator
+        // Compute the initial excess threshold.
         let et = if self.low {
             // Take the low quantile (1 - level)
             self.initial_quantile(1.0 - self.level, data)
@@ -374,7 +375,11 @@ impl SpotDetector {
 }
 
 fn empirical_quantile(level: f64, data: &[f64]) -> f64 {
-    let mut sorted: Vec<f64> = data.iter().copied().filter(|value| value.is_finite()).collect();
+    let mut sorted: Vec<f64> = data
+        .iter()
+        .copied()
+        .filter(|value| value.is_finite())
+        .collect();
     if sorted.is_empty() {
         return f64::NAN;
     }
@@ -638,6 +643,40 @@ mod tests {
         assert_relative_eq!(reused.excess_threshold(), fresh.excess_threshold());
         assert_eq!(reused.nt(), fresh.nt());
         assert_eq!(reused.n(), fresh.n());
+    }
+
+    #[test]
+    fn test_spot_repeated_fit_replaces_previous_tail() {
+        let config = SpotConfig {
+            level: 0.9,
+            ..SpotConfig::default()
+        };
+        let train_a: Vec<f64> = (0..100).map(|i| i as f64).collect();
+        let train_b: Vec<f64> = (0..50).map(|i| i as f64 * 0.5).collect();
+
+        let mut reused = SpotDetector::new_with_options(
+            config.clone(),
+            SpotEstimator::Best,
+            SpotInitialThreshold::Empirical,
+        )
+        .unwrap();
+        reused.fit(&train_a).unwrap();
+        reused.fit(&train_b).unwrap();
+
+        let mut fresh = SpotDetector::new_with_options(
+            config,
+            SpotEstimator::Best,
+            SpotInitialThreshold::Empirical,
+        )
+        .unwrap();
+        fresh.fit(&train_b).unwrap();
+
+        assert_eq!(reused.tail_size(), reused.nt());
+        assert_eq!(reused.tail_size(), fresh.tail_size());
+        assert_eq!(reused.nt(), fresh.nt());
+        assert_eq!(reused.n(), fresh.n());
+        assert_relative_eq!(reused.anomaly_threshold(), fresh.anomaly_threshold());
+        assert_relative_eq!(reused.excess_threshold(), fresh.excess_threshold());
     }
 
     #[test]

--- a/crates/libspot-rs/src/tail.rs
+++ b/crates/libspot-rs/src/tail.rs
@@ -3,9 +3,10 @@
 //! This module implements the Tail structure that models the tail of a distribution
 //! using Generalized Pareto Distribution (GPD) parameters.
 
+use crate::config::SpotEstimator;
 use crate::error::SpotResult;
 
-use crate::estimator::{grimshaw_estimator, mom_estimator};
+use crate::estimator::{grimshaw_estimator, mom_estimator, mom_sample_variance_estimator};
 use crate::math::{xexp, xlog, xpow};
 use crate::peaks::Peaks;
 
@@ -50,13 +51,35 @@ impl Tail {
         self.peaks.reset();
     }
 
-    /// Fit the GPD parameters using the available estimators
-    /// Returns the log-likelihood of the best fit
+    /// Fit the GPD parameters using the default estimator policy.
+    ///
+    /// Returns the selected fit log-likelihood.
     pub fn fit(&mut self) -> f64 {
+        self.fit_with(SpotEstimator::Best)
+    }
+
+    /// Fit the GPD parameters using a selected estimator policy.
+    ///
+    /// Returns the selected fit log-likelihood.
+    pub fn fit_with(&mut self, estimator: SpotEstimator) -> f64 {
         if self.peaks.size() == 0 {
             return f64::NAN;
         }
 
+        match estimator {
+            SpotEstimator::Best => self.fit_best(),
+            SpotEstimator::Mom => self.fit_mom(),
+        }
+    }
+
+    fn fit_mom(&mut self) -> f64 {
+        let (gamma, sigma, llhood) = mom_sample_variance_estimator(&self.peaks);
+        self.gamma = gamma;
+        self.sigma = sigma;
+        llhood
+    }
+
+    fn fit_best(&mut self) -> f64 {
         // Match C implementation exactly: try each estimator and pick best
         let mut max_llhood = f64::NAN;
         let mut tmp_gamma;
@@ -223,6 +246,21 @@ mod tests {
         assert!(!tail.gamma().is_nan());
         assert!(!tail.sigma().is_nan());
         assert!(tail.sigma() > 0.0); // Sigma should be positive
+    }
+
+    #[test]
+    fn test_tail_fit_with_mom_estimator() {
+        let mut tail = Tail::new(10).unwrap();
+
+        for value in [1.0, 1.5, 2.0, 2.5, 3.0, 1.2, 1.8, 2.2] {
+            tail.push(value);
+        }
+
+        let llhood = tail.fit_with(SpotEstimator::Mom);
+        assert!(!llhood.is_nan());
+        assert!(!tail.gamma().is_nan());
+        assert!(!tail.sigma().is_nan());
+        assert!(tail.sigma() > 0.0);
     }
 
     #[test]

--- a/crates/libspot-rs/tests/serialization.rs
+++ b/crates/libspot-rs/tests/serialization.rs
@@ -7,7 +7,10 @@
 #![cfg(feature = "serde")]
 
 use approx::assert_relative_eq;
-use libspot_rs::{Peaks, SpotConfig, SpotDetector, SpotError, SpotStatus, Tail, Ubend};
+use libspot_rs::{
+    Peaks, SpotConfig, SpotDetector, SpotError, SpotEstimator, SpotExcessUpdate,
+    SpotInitialThreshold, SpotStatus, Tail, Ubend,
+};
 
 // ============================================================================
 // SpotConfig Serialization Tests
@@ -259,6 +262,65 @@ fn test_spot_detector_fitted_roundtrip() {
     let (deser_gamma, deser_sigma) = deserialized.tail_parameters();
     assert_relative_eq!(deser_gamma, orig_gamma);
     assert_relative_eq!(deser_sigma, orig_sigma);
+}
+
+#[test]
+fn test_spot_detector_mom_estimator_roundtrip() {
+    let config = SpotConfig {
+        q: 0.001,
+        level: 0.98,
+        max_excess: 10_000,
+        ..SpotConfig::default()
+    };
+    let mut original = SpotDetector::new_with_full_options(
+        config,
+        SpotEstimator::Mom,
+        SpotInitialThreshold::Empirical,
+        SpotExcessUpdate::Greater,
+    )
+    .unwrap();
+
+    let training_data: Vec<f64> = (0..1000)
+        .map(|i| {
+            let x = i as f64 * 0.1;
+            x.sin() + (x * 0.37).cos() * 0.1 + 5.0
+        })
+        .collect();
+    original.fit(&training_data).unwrap();
+
+    let json = serde_json::to_string(&original).unwrap();
+    let deserialized: SpotDetector = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(deserialized.estimator(), SpotEstimator::Mom);
+    assert_eq!(
+        deserialized.initial_threshold(),
+        SpotInitialThreshold::Empirical
+    );
+    assert_eq!(deserialized.excess_update(), SpotExcessUpdate::Greater);
+    assert_eq!(deserialized.n(), original.n());
+    assert_eq!(deserialized.nt(), original.nt());
+    assert_relative_eq!(
+        deserialized.anomaly_threshold(),
+        original.anomaly_threshold()
+    );
+}
+
+#[test]
+fn test_spot_detector_missing_estimator_defaults_to_best() {
+    let original = SpotDetector::new(SpotConfig::default()).unwrap();
+    let mut json = serde_json::to_value(&original).unwrap();
+    json.as_object_mut().unwrap().remove("estimator");
+    json.as_object_mut().unwrap().remove("initial_threshold");
+    json.as_object_mut().unwrap().remove("excess_update");
+
+    let deserialized: SpotDetector = serde_json::from_value(json).unwrap();
+
+    assert_eq!(deserialized.estimator(), SpotEstimator::Best);
+    assert_eq!(deserialized.initial_threshold(), SpotInitialThreshold::P2);
+    assert_eq!(
+        deserialized.excess_update(),
+        SpotExcessUpdate::GreaterOrEqual
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add explicit SPOT estimator, initial threshold, and excess update options
- keep SpotDetector::new defaulting to the existing Best/P2/>= behavior
- add FluxEV-style MOM support using sample variance, empirical thresholding, and strict > excess updates
- preserve serde compatibility for older SpotDetector JSON payloads

## Validation
- cargo fmt --check
- cargo test --manifest-path crates/libspot-rs/Cargo.toml
- cargo clippy --manifest-path crates/libspot-rs/Cargo.toml --all-targets -- -D warnings